### PR TITLE
KeycloakClientException cannot have arbitrary arguments

### DIFF
--- a/src/django_keycloak/auth/backends.py
+++ b/src/django_keycloak/auth/backends.py
@@ -129,9 +129,9 @@ class KeycloakPasswordCredentialsBackend(KeycloakAuthorizationBase):
                     username=username,
                     password=password
                 )
-        except KeycloakClientError:
+        except (KeycloakClientError, django_keycloak.services.exceptions.MissingRealmConfiguration):
             logger.debug('KeycloakPasswordCredentialsBackend: failed to '
-                         'authenticate.')
+                         'authenticate.', exc_info=True)
         else:
             return keycloak_openid_profile.user
 
@@ -155,15 +155,18 @@ class KeycloakIDTokenAuthorizationBackend(KeycloakAuthorizationBase):
         except ExpiredSignatureError:
             # If the signature has expired.
             logger.debug('KeycloakBearerAuthorizationBackend: failed to '
-                         'authenticate due to an expired access token.')
+                         'authenticate due to an expired access token.', exc_info=True)
         except JWTClaimsError as e:
             logger.debug('KeycloakBearerAuthorizationBackend: failed to '
                          'authenticate due to failing claim checks: "%s"'
-                         % str(e))
+                         % str(e), exc_info=True)
         except JWTError:
             # The signature is invalid in any way.
             logger.debug('KeycloakBearerAuthorizationBackend: failed to '
-                         'authenticate due to a malformed access token.')
+                         'authenticate due to a malformed access token.', exc_info=True)
+        except (KeycloakClientError, django_keycloak.services.exceptions.MissingRealmConfiguration):
+            logger.debug('KeycloakBearerAuthorizationBackend: failed to '
+                         'authenticate.', exc_info=True)
         else:
             return oidc_profile.user
 

--- a/src/django_keycloak/services/exceptions.py
+++ b/src/django_keycloak/services/exceptions.py
@@ -6,3 +6,7 @@ class KeycloakOpenIdProfileNotFound(Exception):
 
 class TokensExpired(Exception):
     pass
+
+
+class MissingRealmConfiguration(Exception):
+    pass

--- a/src/django_keycloak/services/realm.py
+++ b/src/django_keycloak/services/realm.py
@@ -1,5 +1,7 @@
+from __future__ import absolute_import
+
 from keycloak.realm import KeycloakRealm
-from keycloak.exceptions import KeycloakClientError
+from .exceptions import MissingRealmConfiguration
 
 try:
     from urllib.parse import urlparse
@@ -72,7 +74,7 @@ def get_issuer(realm):
     try:
         issuer = realm.well_known_oidc['issuer']
     except Exception as e:
-        raise KeycloakClientError(
+        raise MissingRealmConfiguration(
             "Error %s getting issuer.  Check Realm and Client correctly set up.  Run= Refresh OpenID Connect .well-known and Refresh Certificates run in admin" % e)
 
     if realm.server.internal_url:

--- a/src/django_keycloak/tests/services/realm/test_get_issuer.py
+++ b/src/django_keycloak/tests/services/realm/test_get_issuer.py
@@ -1,0 +1,42 @@
+from django.test import TestCase
+
+from django_keycloak.factories import RealmFactory, ServerFactory
+from django_keycloak.tests.mixins import MockTestCaseMixin
+from django.test.utils import override_settings
+
+from django_keycloak.services.exceptions import MissingRealmConfiguration
+from django_keycloak.services.realm import get_issuer
+
+
+class ServicesRealmGetIssuerTestCase(
+        MockTestCaseMixin, TestCase):
+
+    def test_get_issuer_success(self):
+        """
+        Case: issuer is successfully retrieved from a Realm object.
+        Expected: an issuer url.
+        """
+        realm = RealmFactory(
+            server=ServerFactory(
+                internal_url="http://internal.example.com/",
+                url="http://public.example.com/"
+            ),
+            _well_known_oidc='{"issuer":"http://internal.example.com/foo/bar"}'
+        )
+        issuer = get_issuer(realm)
+        self.assertEqual("http://public.example.com/foo/bar", issuer)
+
+    def test_get_issuer_fail(self):
+        """
+        Case: issuer configuration is missing in well-known json object.
+        Expected: a proper exception raised.
+        """
+        realm = RealmFactory(
+            server=ServerFactory(
+                internal_url="http://internal.example.com/",
+                url="http://public.example.com/"
+            ),
+            _well_known_oidc='{}'
+        )
+        with self.assertRaises(MissingRealmConfiguration):
+            get_issuer(realm)


### PR DESCRIPTION
I wonder if you'll ever accept any PR for this fork... 

See https://github.com/Peter-Slump/python-keycloak-client/blob/master/src/keycloak/exceptions.py#L2